### PR TITLE
Fix CircleCI configuration for Codecov integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       - store_artifacts:
           path: coverage.xml
           destination: coverage-report
-          
+
       - store_artifacts:
           path: .htmlcov
           destination: html-coverage-report
@@ -110,6 +110,12 @@ jobs:
           root: .
           paths:
             - coverage.xml
+
+      # Upload coverage report to Codecov directly from this job
+      # This replaces the separate codecov/upload job
+      - codecov/upload:
+          file: coverage.xml
+          flags: python-tests
 
 # Define the workflows that determine when jobs run
 workflows:
@@ -124,11 +130,7 @@ workflows:
   test-and-coverage:
     jobs:
       - run-python-tests
-      - codecov/upload:
-          requires:
-            - run-python-tests
-          file: coverage.xml
-          flags: python-tests
+      # Removed the separate codecov/upload job since we're now uploading directly from the run-python-tests job
 
 # Optional: You can also set up the workflow to run on pull requests only
 # This is useful if you want to save CircleCI credits by not running on every small commit


### PR DESCRIPTION
## Overview
This PR fixes the CircleCI configuration issue that was causing the following error:
```
Error calling workflow: 'test-and-coverage'
Cannot find a definition for job named codecov/upload
```

## Changes
- Modified the CircleCI configuration to use the Codecov orb correctly
- Integrated the Codecov upload step directly into the `run-python-tests` job instead of using it as a separate job in the workflow
- Removed the separate `codecov/upload` job from the workflow definition

## Why This Fix Works
The Codecov orb (v4.0.1) provides a step command that should be used within a job, not as a standalone job in the workflow. This PR changes the configuration to follow the recommended approach in the Codecov orb documentation.

## Testing
The CircleCI build should now complete successfully with the Codecov integration working properly.

## Summary by Sourcery

Fix the CircleCI configuration to properly use the Codecov orb by moving the upload step into the run-python-tests job and removing the standalone upload job

Bug Fixes:
- Resolve CircleCI workflow error for missing codecov/upload job definition

CI:
- Integrate Codecov upload step into run-python-tests job and remove separate codecov/upload job to follow orb usage guidelines