### PR TITLE
Fix CircleCI tests by explicitly installing pytest and pytest-cov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,18 +85,25 @@ jobs:
 
     steps:
       - checkout
-
-      - run:
-          name: "Install pytest and coverage tools"
-          command: |
-            echo "Installing pytest and coverage tools..."
-            pip install pytest pytest-cov
-            echo "Testing tools installed successfully!"
+      
+      # Setup Python dependency caching
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "pyproject.toml" }}-{{ checksum "setup.py" }}
+            # Fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
 
       - run:
           name: "Install project with test dependencies"
           command: |
-            pip install -e .[test]
+            python -m pip install --upgrade pip
+            pip install -e ".[test]"
+
+      # Save the dependency cache for future runs
+      - save_cache:
+          key: v1-dependencies-{{ checksum "pyproject.toml" }}-{{ checksum "setup.py" }}
+          paths:
+            - ~/.cache/pip
 
       - run:
           name: "Run tests with coverage"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,13 @@ jobs:
       - checkout
 
       - run:
+          name: "Install pytest and coverage tools"
+          command: |
+            echo "Installing pytest and coverage tools..."
+            pip install pytest pytest-cov
+            echo "Testing tools installed successfully!"
+
+      - run:
           name: "Install project with test dependencies"
           command: |
             pip install -e .[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,8 @@ dependencies = [
 # Optional dependencies for different use cases
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
+    "pytest==7.4.0",
+    "pytest-cov==4.1.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "pre-commit>=3.0.0",

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
         "torch": ["torch>=1.12.0"],
         "tensorflow": ["tensorflow>=2.9.0"],
         "test": [
-            "pytest",
-            "pytest-cov",
+            "pytest==7.4.0",
+            "pytest-cov==4.1.0",
         ],
         "dev": [
             "ruff==0.4.4",


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add a step in CircleCI config to install pytest and pytest-cov before running tests.